### PR TITLE
Make zk2 runnable

### DIFF
--- a/k2/Makefile
+++ b/k2/Makefile
@@ -6,7 +6,7 @@ endif
 
 VERSION_STRING := ${VERSION_NUMBER}+${BUILD_NUMBER}
 
-PYTHON := python3.6
+PYTHON := python3
 
 PY_SOURCES := $(shell find k2 -type f -name '*.py')
 PY_SOURCES += $(shell find addons -type f -name '*.py')

--- a/k2/addons/k2-consolerunner/consolerunner/systest/test_consolerunner.py
+++ b/k2/addons/k2-consolerunner/consolerunner/systest/test_consolerunner.py
@@ -1,6 +1,16 @@
-from zaf.component.decorator import requires
+from zaf.component.decorator import component, requires
+
+from k2.runner.exceptions import SkipException
 
 
+@component(name='SkipIfMultiRunnerIosMissing')
+@requires(manager='ExtensionManager')
+def skip_if_multi_runner_is_missing(manager):
+    if not manager.extensions_with_name('multirunner'):
+        raise SkipException('Multirunner is missing')
+
+
+@requires(prereq='SkipIfMultiRunnerIosMissing')
 @requires(zk2='Zk2')
 def test_console_runner_with_no_patterns(zk2):
     result = zk2(
@@ -17,6 +27,7 @@ def test_console_runner_with_no_patterns(zk2):
     assert 'Failed:  0' in result.stdout
 
 
+@requires(prereq='SkipIfMultiRunnerIosMissing')
 @requires(zk2='Zk2')
 def test_console_runner_with_a_failure(zk2):
     result = zk2(
@@ -34,6 +45,7 @@ def test_console_runner_with_a_failure(zk2):
     assert 'Failed:  1' in result.stdout
 
 
+@requires(prereq='SkipIfMultiRunnerIosMissing')
 @requires(zk2='Zk2')
 def test_console_runner_with_a_success(zk2):
     result = zk2(
@@ -51,6 +63,7 @@ def test_console_runner_with_a_success(zk2):
     assert 'Failed:  0' in result.stdout
 
 
+@requires(prereq='SkipIfMultiRunnerIosMissing')
 @requires(zk2='Zk2')
 def test_console_runner_with_mixed_results(zk2):
     result = zk2(
@@ -69,6 +82,7 @@ def test_console_runner_with_mixed_results(zk2):
     assert 'Failed:  1' in result.stdout
 
 
+@requires(prereq='SkipIfMultiRunnerIosMissing')
 @requires(zk2='Zk2')
 def test_console_runner_with_multiple_binaries(zk2):
     result = zk2(
@@ -90,6 +104,7 @@ def test_console_runner_with_multiple_binaries(zk2):
     assert 'Failed:  1' in result.stdout
 
 
+@requires(prereq='SkipIfMultiRunnerIosMissing')
 @requires(zk2='Zk2')
 def test_console_runner_all_verdicts(zk2):
     result = zk2(

--- a/k2/addons/k2-consolerunner/consolerunner/test/test_consolerunner.py
+++ b/k2/addons/k2-consolerunner/consolerunner/test/test_consolerunner.py
@@ -9,7 +9,7 @@ from zaf.messages.dispatchers import LocalMessageQueue
 
 from k2.runner import TEST_CASE_FINISHED, TEST_CASE_STARTED, TEST_RUN_FINISHED, TEST_RUN_STARTED
 from k2.runner.testcase import Verdict
-from multirunner import MULTI_RUNNER_ENDPOINT
+from multirunner import MULTI_RUNNER_ENDPOINT, TEST_SUBRUN
 
 from .. import CONSOLE_BINARY_FAILED_PATTERN, CONSOLE_BINARY_PASSED_PATTERN, CONSOLE_BINARY_PATH, \
     CONSOLE_BINARY_TIMEOUT, CONSOLE_binaryid
@@ -35,8 +35,10 @@ class TestConsoleRunner(TestCase):
         return ExtensionTestHarness(
             ConsoleRunner,
             endpoints_and_messages={
-                MULTI_RUNNER_ENDPOINT:
-                [TEST_RUN_STARTED, TEST_RUN_FINISHED, TEST_CASE_STARTED, TEST_CASE_FINISHED]
+                MULTI_RUNNER_ENDPOINT: [
+                    TEST_RUN_STARTED, TEST_RUN_FINISHED, TEST_CASE_STARTED, TEST_CASE_FINISHED,
+                    TEST_SUBRUN
+                ]
             },
             config=config,
         )

--- a/k2/addons/k2-consolerunner/multirunner/__init__.py
+++ b/k2/addons/k2-consolerunner/multirunner/__init__.py
@@ -1,0 +1,9 @@
+from zaf.config.options import ConfigOptionId
+from zaf.messages.message import EndpointId, MessageId
+
+MULTI_RUNNER_ENABLED = ConfigOptionId(
+    'multirunner.enabled', 'Should multi-runner be enabled', option_type=bool, default=True)
+
+MULTI_RUNNER_ENDPOINT = EndpointId('multirunner', 'stub')
+
+TEST_SUBRUN = MessageId('TEST_SUBRUN', 'stub')

--- a/k2/addons/k2-linuxutils/healthcheck/__init__.py
+++ b/k2/addons/k2-linuxutils/healthcheck/__init__.py
@@ -1,0 +1,9 @@
+from zaf.messages.message import EndpointId, MessageId
+
+PERFORM_HEALTH_CHECK = MessageId('PERFORM_HEALTH_CHECK', 'stub')
+
+HEALTH_CHECK_ENDPOINT = EndpointId('healthcheck', 'stub')
+
+
+class HealthCheckError(Exception):
+    pass

--- a/k2/addons/k2-metrics/setup.py
+++ b/k2/addons/k2-metrics/setup.py
@@ -17,9 +17,9 @@ setup(
             'systest'
         ]),
     install_requires=[
-        'numpy==1.13.3',
-        'matplotlib==2.1.1',
-        'pandas==0.20.1',
+        'numpy==1.19.4',
+        'matplotlib==3.3.3',
+        'pandas==1.1.4',
     ],
     entry_points={
         'k2.addons': [

--- a/k2/addons/k2-serial/setup.py
+++ b/k2/addons/k2-serial/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-serial',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='Serial support for K2',
-    long_description=(
-        'Allows K2 to use serial (UART) to connect to and execute commands on SUT.'),
+    long_description=('Allows K2 to use serial (UART) to connect to and execute commands on SUT.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-serial/setup.py
+++ b/k2/addons/k2-serial/setup.py
@@ -22,6 +22,7 @@ setup(
         'k2.addons': [
             'zserial = zserial.serial:SerialExtension',
             'zserialcc = zserial.serialcc:SerialConnectionCheck',
+            'zserialcommand = zserial.serialcommand:SerialFrameworkExtension',
         ],
     },
 )

--- a/k2/addons/k2-sutevents/LICENSE
+++ b/k2/addons/k2-sutevents/LICENSE
@@ -1,0 +1,201 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/k2/addons/k2-sutevents/setup.py
+++ b/k2/addons/k2-sutevents/setup.py
@@ -1,0 +1,22 @@
+import os
+
+from setuptools import find_packages, setup
+
+setup(
+    name='k2-sutevents',
+    version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
+    description='Sutevents stub',
+    long_description=('Stub.'),
+    maintainer='Patrik Dahlström',
+    maintainer_email='risca@dalakolonin.se',
+    license='Apache 2.0',
+    packages=find_packages(
+        exclude=[
+            '*.test', '*.test.*', 'test.*', 'test', '*.systest', '*.systest.*', 'systest.*',
+            'systest'
+        ]),
+    install_requires=[],
+    entry_points={
+        'k2.addons': [],
+    },
+)

--- a/k2/addons/k2-sutevents/sutevents/__init__.py
+++ b/k2/addons/k2-sutevents/sutevents/__init__.py
@@ -1,0 +1,3 @@
+from zaf.messages.message import MessageId
+
+LOG_LINE_RECEIVED = MessageId('LOG_LINE_RECEIVED', """Log line received""")

--- a/k2/addons/k2-telnet/setup.py
+++ b/k2/addons/k2-telnet/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-telnet',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='Telnet support for K2',
-    long_description=(
-        'Allows K2 to use telnet to connect to and execute commands on SUT.'),
+    long_description=('Allows K2 to use telnet to connect to and execute commands on SUT.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/maketools/environment.mk
+++ b/k2/maketools/environment.mk
@@ -1,4 +1,4 @@
-DOCKER_REGISTRY := docker.zenterio.lan
+DOCKER_REGISTRY := quay.io
 image_14 := zenterio/pythontest.u14
 image_16 := zenterio/pythontest.u16
 image_18 := zenterio/pythontest.u18
@@ -46,12 +46,13 @@ define TEST_NODE
 ./docker/markers/docker_node_$(1)_venv.marker: ./docker/markers/docker_node_$(1)_built.marker requirements.txt requirements-dev.txt setup.py addons/*/setup.py
 	rm -rf .venv/*
 	${PYTHON} -m venv .venv
+	cp pip.conf .venv/
 	.venv/bin/${PYTHON} .venv/bin/pip install --upgrade setuptools
 	.venv/bin/${PYTHON} .venv/bin/pip install --upgrade --force-reinstall pip
 	cp pip.conf .venv/pip.conf
-	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep -v addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip --trusted-host pip.zenterio.lan install
-	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip --trusted-host pip.zenterio.lan install -e
-	.venv/bin/${PYTHON} .venv/bin/pip --trusted-host pip.zenterio.lan install -e .
+	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep -v addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip install
+	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip install -e
+	.venv/bin/${PYTHON} .venv/bin/pip install -e .
 	touch $$@
 
 prepare_node_$(1): ./docker/markers/docker_node_$(1)_venv.marker

--- a/k2/pip.conf
+++ b/k2/pip.conf
@@ -1,2 +1,5 @@
 [global]
-index-url = http://pip.zenterio.lan/simple
+index-url = http://pip.example.com:8080/
+
+[install]
+trusted-host = pip.example.com

--- a/k2/requirements-dev.txt
+++ b/k2/requirements-dev.txt
@@ -16,4 +16,5 @@ Sphinx==1.7.2
 sphinxcontrib-plantuml==0.11
 sphinxprettysearchresults==0.3.4
 testfixtures==5.4.0
+xmldiff==2.4
 yapf==0.20.0

--- a/k2/requirements-dev.txt
+++ b/k2/requirements-dev.txt
@@ -10,7 +10,6 @@ flake8-string-format==0.2.3
 flake8==3.7.6
 flake8_tuple==0.2.13
 isort==4.3.0
-pdoc==0.3.2
 pydocstyle==2.1.1
 sphinx-rtd-theme==0.3.0
 Sphinx==1.7.2

--- a/k2/requirements.txt
+++ b/k2/requirements.txt
@@ -1,4 +1,3 @@
---trusted-host pip.zenterio.lan
 addons/k2-addon
 addons/k2-connectioncheck
 addons/k2-consolerunner
@@ -15,21 +14,22 @@ addons/k2-profiling
 addons/k2-serial
 addons/k2-telnet
 addons/k2-zelenium
-numpy==1.13.3 --only-binary numpy
+numpy==1.19.4 --only-binary numpy
 arrow==0.12.1
 docker-pycreds==0.4.0
 docker==3.7.0
 fastentrypoints==0.10
 GitPython==2.1.9
-httpretty==0.9.5
+httpretty==1.0.3
 jinja2==2.9.6
-matplotlib==2.1.1 --only-binary matplotlib
+junit-xml==1.8
+matplotlib==3.3.3 --only-binary matplotlib
 nose-timer==0.7.3
 nose==1.3.7
-pandas==0.20.1 --only-binary pandas
+pandas==1.1.4 --only-binary pandas
 pretenders==1.4.4
+pyserial==3.5
 python-jenkins==1.4.0
-junit-xml==1.8
 pytracing==0.2
 selenium==3.9.0
 simple-websocket-server==0.4.0
@@ -37,4 +37,4 @@ testinfra==1.16.0 --only-binary testinfra
 thrift==0.10.0
 wakeonlan==1.1.6
 websocket-client==0.55.0
-zenterio-zaf==0.28.1
+zenterio-zaf

--- a/k2/requirements.txt
+++ b/k2/requirements.txt
@@ -12,6 +12,7 @@ addons/k2-orchestration
 addons/k2-power
 addons/k2-profiling
 addons/k2-serial
+addons/k2-sutevents
 addons/k2-telnet
 addons/k2-zelenium
 numpy==1.19.4 --only-binary numpy

--- a/k2/systest/systest_config.yaml
+++ b/k2/systest/systest_config.yaml
@@ -3,6 +3,7 @@ plugins.paths:
   - systest/systest_plugins
 ext.connectioncheck.enabled: false
 ext.coredumps.enabled: false
+ext.dummypowermeter.enabled: false
 ext.gtestrunner.enabled: false
 ext.healthcheck.enabled: false
 ext.iprcu.enabled: false

--- a/k2/systest/systest_plugins/serialmock/serialmock.py
+++ b/k2/systest/systest_plugins/serialmock/serialmock.py
@@ -2,10 +2,9 @@ import logging
 import subprocess
 from tempfile import mktemp
 
+from serial import Serial
 from zaf.component.decorator import component
 from zaf.extensions.extension import CommandExtension, get_logger_name
-
-from serial import Serial
 
 logger = logging.getLogger(get_logger_name('k2', 'serialmock'))
 logger.addHandler(logging.NullHandler())

--- a/zaf/zaf/application/metadata.py
+++ b/zaf/zaf/application/metadata.py
@@ -108,11 +108,7 @@ class ZafMetadata(object):
                             command for command in sorted(ext_class.commands, key=lambda c: c.name)
                             if self._metadata_filter.include_command(command)
                         ],
-                        [
-                            endpoint
-                            for endpoint in sorted(
-                                ext_class.endpoints_and_messages.keys(), key=lambda e: e.name)
-                        ],
+                        sorted(ext_class.endpoints_and_messages.keys(), key=lambda e: e.name),
                         [
                             message
                             for endpoint in ext_class.endpoints_and_messages.keys()

--- a/zaf/zaf/builtin/click/click.py
+++ b/zaf/zaf/builtin/click/click.py
@@ -215,10 +215,7 @@ class ClickCommandWithConfigOptions(click.MultiCommand):
         self.config = config
         self._application_context = application_context
         self._command = command
-        self._all_commands = [
-            command for command in get_applicable_commands(all_commands, self._application_context)
-        ]
-
+        self._all_commands = list(get_applicable_commands(all_commands, self._application_context))
         self._command_config_options = command_config_options
         self._ignore_hidden = ignore_hidden
         self._disable_required = disable_required

--- a/zaf/zaf/builtin/logging/test/test_file.py
+++ b/zaf/zaf/builtin/logging/test/test_file.py
@@ -120,9 +120,9 @@ class FileLoggerHarness(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.getlogger_patch.__exit__()
-        self.handler_constructor_patch.__exit__()
-        self.harness.__exit__()
+        self.getlogger_patch.__exit__(exc_type, exc_val, exc_tb)
+        self.handler_constructor_patch.__exit__(exc_type, exc_val, exc_tb)
+        self.harness.__exit__(exc_type, exc_val, exc_tb)
 
 
 def mock_logger(level=logging.INFO):

--- a/zaf/zaf/builtin/logging/test/test_logging.py
+++ b/zaf/zaf/builtin/logging/test/test_logging.py
@@ -97,7 +97,7 @@ class RootLoggerTest(unittest.TestCase):
 
         config = ConfigManager()
         config.set(LOG_LEVEL, 'warning')
-        config.set(LOG_FORMAT, 'hej')
+        config.set(LOG_FORMAT, None)
         config.set(LOG_DIR, '.')
         config.set(APPLICATION_NAME, 'k2')
         config.set(ENABLED_EXTENSIONS, ['extensionname'])

--- a/zaf/zaf/builtin/remote/remote.py
+++ b/zaf/zaf/builtin/remote/remote.py
@@ -119,12 +119,15 @@ def create_service(messagebus_arg):
     class MessageBusService(rpyc.Service):
         messagebus = messagebus_arg
 
-        def on_connect(self):
+        @classmethod
+        def on_connect(self, conn):
             pass
 
-        def on_disconnect(self):
+        @classmethod
+        def on_disconnect(self, conn):
             pass
 
+        @classmethod
         def exposed_trigger_event(
                 self, serialized_message_id, serialized_endpoint_id, serialized_entity,
                 serialized_data):
@@ -139,6 +142,7 @@ def create_service(messagebus_arg):
 
             self.messagebus.trigger_event(message_id, endpoint_id, entity, data)
 
+        @classmethod
         def exposed_send_request(
                 self,
                 serialized_message_id,
@@ -162,6 +166,7 @@ def create_service(messagebus_arg):
             if not is_async:
                 return futures
 
+        @classmethod
         def exposed_local_message_queue(
                 self, serialized_message_ids, serialized_endpoint_ids, serialized_entities):
             message_ids = pickle.loads(serialized_message_ids)
@@ -170,6 +175,7 @@ def create_service(messagebus_arg):
 
             return LocalMessageQueue(self.messagebus, message_ids, endpoint_ids, entities)
 
+        @classmethod
         def exposed_define_endpoints_and_messages(self, serialized_endpoints_and_messages):
             endpoints_and_messages = pickle.loads(serialized_endpoints_and_messages)
 

--- a/zaf/zaf/builtin/remote/test/test_remote.py
+++ b/zaf/zaf/builtin/remote/test/test_remote.py
@@ -76,21 +76,21 @@ class RemoteServiceTest(unittest.TestCase):
 
     def test_exposed_trigger_event_depickles_message_info_and_forwards_event(self):
         messagebus = Mock()
-        service = create_service(messagebus)(Mock())
+        service = create_service(messagebus)
         service.exposed_trigger_event(
             PICKLED_MESSAGE, PICKLED_ENDPOINT, PICKLED_ENTITY, PICKLED_DATA)
         messagebus.trigger_event.assert_called_with(MESSAGE, ENDPOINT, ENTITY, DATA)
 
     def test_exposed_send_request_depickles_message_info_and_forwards_request(self):
         messagebus = Mock()
-        service = create_service(messagebus)(Mock())
+        service = create_service(messagebus)
         service.exposed_send_request(
             PICKLED_MESSAGE, PICKLED_ENDPOINT, PICKLED_ENTITY, PICKLED_DATA)
         messagebus.send_request.assert_called_with(MESSAGE, ENDPOINT, ENTITY, DATA)
 
     def test_exposed_local_message_queue_depickles_message_info_and_returns_a_queue(self):
         messagebus = Mock()
-        service = create_service(messagebus)(Mock())
+        service = create_service(messagebus)
         queue = service.exposed_local_message_queue(
             PICKLED_MESSAGES, PICKLED_ENDPOINTS, PICKLED_ENTITIES)
         self.assertEqual(type(queue), LocalMessageQueue)

--- a/zaf/zaf/extensions/manager.py
+++ b/zaf/zaf/extensions/manager.py
@@ -250,7 +250,7 @@ class ExtensionManager(object):
             commandid_extends = extends - command_capability_extends
 
             if (command is None or command in commandid_extends
-                    or command in {cmd.name for cmd in commandid_extends}
+                    or command in (cmd.name for cmd in commandid_extends)
                     or (command_capability_extends and command_capability_extends <= uses)):
                 matching_extensions.append(extension)
 

--- a/zaf/zaf/messages/decorator.py
+++ b/zaf/zaf/messages/decorator.py
@@ -5,8 +5,8 @@ The purpose of these decorators is to provide a short-hand for defining dispatch
 of the boilerplate code associated with setting up dispatchers.
 
 
-Example:
-
+Example
+-------
 .. code-block:: python
 
     # Simple extension with a single dispatcher, set up manually:
@@ -41,7 +41,9 @@ the resulting dispatcher object is owned by the extension manager and can not ea
 from an extension instance.
 
 Both methods of setting up dispatchers may be combined in a single extension.
+
 """
+
 import inspect
 
 from .dispatchers import CallbackDispatcher, ConcurrentDispatcher, SequentialDispatcher, \

--- a/zaf/znake.yaml
+++ b/zaf/znake.yaml
@@ -96,7 +96,7 @@ znake:
         - nose-timer<1.0,>=0
         - ordered-set<3.0,>=2
         - pytracing<1.0,>=0
-        - rpyc<4.0,>=3
+        - rpyc>=4.0
         - ruamel.yaml<1.0,>=0
         - voluptuous<1.0,>=0
     requirements_dev:


### PR DESCRIPTION
Updated enough to build znake, zaf, and run zk2 (with monitors disabled).

It is necessary to search/replace or spoof example.com to get it to work. It is designed for a local pip mirror. I found it next to impossible to make it work in both an offline environment and one where it's connected to the internet. This potentially should work, if you just redirect example.com to a pypi mirror.

To make the docker images work, you have to manually install them locally and then run znake with `--no-pull` (and possibly `--network=host`)