### PR TITLE
k2: add sispm power switch

### DIFF
--- a/k2/addons/k2-sispmpowerswitch/setup.py
+++ b/k2/addons/k2-sispmpowerswitch/setup.py
@@ -1,0 +1,24 @@
+import os
+
+from setuptools import find_packages, setup
+
+setup(
+    name='k2-sispmpowerswitch',
+    version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
+    description='Addon for interacting with Silver Shield PM devices.',
+    maintainer='Patrik Dahlström',
+    maintainer_email='risca@dalakolonin.se',
+    license='Apache 2.0',
+    packages=find_packages(
+        exclude=[
+            '*.test', '*.test.*', 'test.*', 'test', '*.systest', '*.systest.*', 'systest.*',
+            'systest'
+        ]),
+    install_requires=[],
+    entry_points={
+        'k2.addons': [
+            'sispmpowerswitch = sispmpowerswitch.sispmpowerswitch:SispmPowerSwitch',
+            'sispmpowerswitchframeworkextension = sispmpowerswitch.sispmpowerswitch:SispmPowerSwitchFrameworkExtension',
+        ],
+    },
+)

--- a/k2/addons/k2-sispmpowerswitch/sispmpowerswitch/__init__.py
+++ b/k2/addons/k2-sispmpowerswitch/sispmpowerswitch/__init__.py
@@ -1,0 +1,13 @@
+from zaf.config.options import ConfigOptionId
+from zaf.messages.message import EndpointId
+
+from k2.sut import SUT
+
+SISPM_DEVICE = ConfigOptionId(
+    'sispmpowerswitch.device', "Which device 'n' to talk to", at=SUT, option_type=int, default=0)
+
+SISPM_OUTLET = ConfigOptionId(
+    'sispmpowerswitch.outlet', 'Which outlet to use', at=SUT, option_type=int, default=1)
+
+SISPM_POWER_SWITCH_ENDPOINT = EndpointId(
+    'sispmpowerswitch', 'Endpoint for Silver Shield PM USB relay')

--- a/k2/addons/k2-sispmpowerswitch/sispmpowerswitch/sispmpowerswitch.py
+++ b/k2/addons/k2-sispmpowerswitch/sispmpowerswitch/sispmpowerswitch.py
@@ -1,0 +1,117 @@
+"""
+SiS-PM (Silver Shield PM) Control for K2.
+
+This component simply wraps the sispmctl command with the proper switches for controlling a power outlet.
+"""
+
+import logging
+import subprocess
+
+from zaf.component.decorator import component, requires
+from zaf.component.util import add_cans
+from zaf.config.options import ConfigOption
+from zaf.extensions.extension import AbstractExtension, CommandExtension, ExtensionConfig, \
+    FrameworkExtension, get_logger_name
+from zaf.messages.dispatchers import SequentialDispatcher
+
+from k2.cmd.run import RUN_COMMAND
+from k2.sut import SUT
+from powerswitch import AVAILABLE_POWER_SWITCHES, K2_POWER_COMPONENT, POWER_SWITCH, \
+    POWER_SWITCH_POWER_STATE, POWER_SWITCH_POWEROFF, POWER_SWITCH_POWERON
+from powerswitch.powercommand import POWER_COMMAND
+from powerswitch.powerswitch import PowerSwitch
+
+from . import SISPM_DEVICE, SISPM_OUTLET, SISPM_POWER_SWITCH_ENDPOINT
+
+logger = logging.getLogger(get_logger_name('k2', 'sispmpowerswitch'))
+logger.addHandler(logging.NullHandler())
+
+
+@CommandExtension(
+    name='sispmpowerswitch',
+    extends=[RUN_COMMAND, POWER_COMMAND],
+    config_options=[
+        ConfigOption(SUT, required=True, instantiate_on=True),
+        ConfigOption(POWER_SWITCH, required=False),
+        ConfigOption(SISPM_DEVICE, required=False),
+        ConfigOption(SISPM_OUTLET, required=False),
+    ],
+    endpoints_and_messages={
+        SISPM_POWER_SWITCH_ENDPOINT:
+        [POWER_SWITCH_POWER_STATE, POWER_SWITCH_POWERON, POWER_SWITCH_POWEROFF]
+    },
+    groups=['powerswitch'],
+)
+class SispmPowerSwitch(AbstractExtension):
+    """SiS-PM power switch."""
+
+    def __init__(self, config, instances):
+        self.is_active = False
+        if config.get(POWER_SWITCH) == 'sispm':
+            self.is_active = True
+            self.entity = instances[SUT]
+            self.device = config.get(SISPM_DEVICE)
+            self.outlet = config.get(SISPM_OUTLET)
+            self.dispatcher = None
+
+    def register_components(self, component_manager):
+        if self.is_active:
+            sut = component_manager.get_unique_class_for_entity(self.entity)
+            add_cans(sut, ['power_switch'])
+
+            @requires(sut='Sut', can=['power_switch'])
+            @requires(messagebus='MessageBus')
+            @component(name=K2_POWER_COMPONENT, can=['power_switch'])
+            def Sispm(sut, messagebus):
+                return PowerSwitch(messagebus, sut.entity, SISPM_POWER_SWITCH_ENDPOINT)
+
+    def register_dispatchers(self, messagebus):
+        if self.is_active:
+            self.dispatcher = SequentialDispatcher(messagebus, self.handle_message)
+            self.dispatcher.register(
+                [POWER_SWITCH_POWER_STATE, POWER_SWITCH_POWERON, POWER_SWITCH_POWEROFF],
+                [SISPM_POWER_SWITCH_ENDPOINT],
+                entities=[self.entity])
+
+    def destroy(self):
+        if self.is_active and self.dispatcher is not None:
+            self.dispatcher.destroy()
+            self.dispatcher = None
+
+    def handle_message(self, message):
+        return {
+            POWER_SWITCH_POWER_STATE: self.get_state,
+            POWER_SWITCH_POWEROFF: self.turn_off,
+            POWER_SWITCH_POWERON: self.turn_on
+        }[message.message_id]()
+
+    def get_state(self):
+        """Return current relay state."""
+        return self._run_sispmctl(switch='-g')
+
+    def turn_on(self):
+        """Turn on relay."""
+        self._run_sispmctl(switch='-o')
+
+    def turn_off(self):
+        """Turn off relay."""
+        self._run_sispmctl(switch='-f')
+
+    def _run_sispmctl(self, switch):
+        command = [
+            'sispmctl', '-q', '-n', '-d', '{device}'.format(device=self.device), switch,
+            '{outlet}'.format(outlet=self.outlet)
+        ]
+        stdout = subprocess.check_output(command)
+        return True if b'1' in stdout else False if b'0' in stdout else None
+
+
+@FrameworkExtension(name='sispmpowerswitch', groups=['powerswitch'])
+class SispmPowerSwitchFrameworkExtension(object):
+    """Provides the sispmpowerswitch command."""
+
+    def __init__(self, config, instances):
+        pass
+
+    def get_config(self, config, requested_config_options, requested_command_config_options):
+        return ExtensionConfig({AVAILABLE_POWER_SWITCHES.name: ['sispm']}, 1, 'sispmpowerswitch')

--- a/k2/requirements.txt
+++ b/k2/requirements.txt
@@ -16,6 +16,7 @@ addons/k2-orchestration
 addons/k2-power
 addons/k2-profiling
 addons/k2-serial
+addons/k2-sispmpowerswitch
 addons/k2-sutevents
 addons/k2-telnet
 addons/k2-zelenium

--- a/k2/systest/systest_config.yaml
+++ b/k2/systest/systest_config.yaml
@@ -15,6 +15,7 @@ ext.powermonitor.enabled: false
 ext.powerswitch.enabled: false
 ext.powerswitchcc.enabled: false
 ext.rcu.enabled: false
+ext.sispmpowerswitch.enabled: false
 ext.stbrecover.enabled: false
 ext.sut.enabled: false
 ext.sutevents.enabled: false


### PR DESCRIPTION
Simple power switch that extends the `POWER_COMMAND` (`zk2 powerswitch`) and `RUN_COMMAND` (`zk2 run`) commands. It's a USB controlled power outlet that is controlled through USB. It requires a userspace program called `sispmctl` to communicate with the SiSPM. The python code simply wraps this program. For more information, see: http://sispmctl.sourceforge.net/

I don't expect anyone to actually have this power switch because it is indeed ancient, but _I have it_ and this is a nice little starter component to implement =)