### PR TITLE
Update K2 to pass `make check`

### DIFF
--- a/k2/Makefile
+++ b/k2/Makefile
@@ -6,7 +6,7 @@ endif
 
 VERSION_STRING := ${VERSION_NUMBER}+${BUILD_NUMBER}
 
-PYTHON := python3.6
+PYTHON := python3
 
 PY_SOURCES := $(shell find k2 -type f -name '*.py')
 PY_SOURCES += $(shell find addons -type f -name '*.py')

--- a/k2/addons/k2-consolerunner/consolerunner/test/test_consolerunner.py
+++ b/k2/addons/k2-consolerunner/consolerunner/test/test_consolerunner.py
@@ -9,7 +9,7 @@ from zaf.messages.dispatchers import LocalMessageQueue
 
 from k2.runner import TEST_CASE_FINISHED, TEST_CASE_STARTED, TEST_RUN_FINISHED, TEST_RUN_STARTED
 from k2.runner.testcase import Verdict
-from multirunner import MULTI_RUNNER_ENDPOINT
+from multirunner import MULTI_RUNNER_ENDPOINT, TEST_SUBRUN
 
 from .. import CONSOLE_BINARY_FAILED_PATTERN, CONSOLE_BINARY_PASSED_PATTERN, CONSOLE_BINARY_PATH, \
     CONSOLE_BINARY_TIMEOUT, CONSOLE_binaryid
@@ -35,8 +35,10 @@ class TestConsoleRunner(TestCase):
         return ExtensionTestHarness(
             ConsoleRunner,
             endpoints_and_messages={
-                MULTI_RUNNER_ENDPOINT:
-                [TEST_RUN_STARTED, TEST_RUN_FINISHED, TEST_CASE_STARTED, TEST_CASE_FINISHED]
+                MULTI_RUNNER_ENDPOINT: [
+                    TEST_RUN_STARTED, TEST_RUN_FINISHED, TEST_CASE_STARTED, TEST_CASE_FINISHED,
+                    TEST_SUBRUN
+                ]
             },
             config=config,
         )

--- a/k2/addons/k2-gtestbinaryrunner/gtestbinaryrunner/test/test_gtestbinaryrunner.py
+++ b/k2/addons/k2-gtestbinaryrunner/gtestbinaryrunner/test/test_gtestbinaryrunner.py
@@ -8,8 +8,7 @@ from zaf.messages.dispatchers import LocalMessageQueue
 
 from k2.runner import TEST_CASE_FINISHED, TEST_CASE_STARTED, TEST_RUN_FINISHED, TEST_RUN_STARTED
 from k2.runner.testcase import Verdict
-from multirunner import MULTI_RUNNER_ENDPOINT
-from multirunner.multirunner import TEST_SUBRUN
+from multirunner import MULTI_RUNNER_ENDPOINT, TEST_SUBRUN
 
 from .. import GTEST_BINARY_PATH, GTEST_FILTER, GTEST_XML_REPORT_PATH, GTEST_binaryid
 from ..gtestbinaryrunner import GtestBinaryRunner

--- a/k2/addons/k2-gtestbinaryrunner/setup.py
+++ b/k2/addons/k2-gtestbinaryrunner/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-gtestbinaryrunner',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='K2 GTest runner',
-    long_description=(
-        'Run GTest binaries on SUT.'),
+    long_description=('Run GTest binaries on SUT.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-gude/setup.py
+++ b/k2/addons/k2-gude/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-gude',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='K2 Gude Power Control',
-    long_description=(
-        'Interact with Gude Power Control unit.'),
+    long_description=('Interact with Gude Power Control unit.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-healthcheck/setup.py
+++ b/k2/addons/k2-healthcheck/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-healthcheck',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='K2 SUT Health check',
-    long_description=(
-        'Event definition and interface for SUT health checking.'),
+    long_description=('Event definition and interface for SUT health checking.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-metrics/setup.py
+++ b/k2/addons/k2-metrics/setup.py
@@ -17,9 +17,9 @@ setup(
             'systest'
         ]),
     install_requires=[
-        'numpy==1.13.3',
-        'matplotlib==2.1.1',
-        'pandas==0.20.1',
+        'numpy==1.19.4',
+        'matplotlib==3.3.3',
+        'pandas==1.1.4',
     ],
     entry_points={
         'k2.addons': [

--- a/k2/addons/k2-multirunner/setup.py
+++ b/k2/addons/k2-multirunner/setup.py
@@ -7,7 +7,8 @@ setup(
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='K2 Multirunner',
     long_description=(
-        'Alternative runner to the built-in runner. Allows multiple sub-runners to collectively generate a vertict.'),
+        'Alternative runner to the built-in runner. Allows multiple sub-runners to collectively generate a vertict.'
+    ),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-networking/setup.py
+++ b/k2/addons/k2-networking/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-networking',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='K2 network utils',
-    long_description=(
-        'Components to handle network related.'),
+    long_description=('Components to handle network related.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-serial/setup.py
+++ b/k2/addons/k2-serial/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-serial',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='Serial support for K2',
-    long_description=(
-        'Allows K2 to use serial (UART) to connect to and execute commands on SUT.'),
+    long_description=('Allows K2 to use serial (UART) to connect to and execute commands on SUT.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-sutevents/setup.py
+++ b/k2/addons/k2-sutevents/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-sutevents',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='SUT Event definitions',
-    long_description=(
-        'Common event definition describing events on the SUT.'),
+    long_description=('Common event definition describing events on the SUT.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/addons/k2-telnet/setup.py
+++ b/k2/addons/k2-telnet/setup.py
@@ -6,8 +6,7 @@ setup(
     name='k2-telnet',
     version='0.0.1+' + os.getenv('BUILD_NUMBER', '0'),
     description='Telnet support for K2',
-    long_description=(
-        'Allows K2 to use telnet to connect to and execute commands on SUT.'),
+    long_description=('Allows K2 to use telnet to connect to and execute commands on SUT.'),
     maintainer='Zenterio AB',
     maintainer_email='foss@zenterio.com',
     license='Apache 2.0',

--- a/k2/maketools/environment.mk
+++ b/k2/maketools/environment.mk
@@ -1,4 +1,4 @@
-DOCKER_REGISTRY := docker.zenterio.lan
+DOCKER_REGISTRY := quay.io
 image_14 := zenterio/pythontest.u14
 image_16 := zenterio/pythontest.u16
 image_18 := zenterio/pythontest.u18
@@ -46,12 +46,13 @@ define TEST_NODE
 ./docker/markers/docker_node_$(1)_venv.marker: ./docker/markers/docker_node_$(1)_built.marker requirements.txt requirements-dev.txt setup.py addons/*/setup.py
 	rm -rf .venv/*
 	${PYTHON} -m venv .venv
+	cp pip.conf .venv/
 	.venv/bin/${PYTHON} .venv/bin/pip install --upgrade setuptools
 	.venv/bin/${PYTHON} .venv/bin/pip install --upgrade --force-reinstall pip
 	cp pip.conf .venv/pip.conf
-	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep -v addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip --trusted-host pip.zenterio.lan install
-	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip --trusted-host pip.zenterio.lan install -e
-	.venv/bin/${PYTHON} .venv/bin/pip --trusted-host pip.zenterio.lan install -e .
+	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep -v addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip install
+	cat requirements.txt requirements-dev.txt | grep -v trusted-host | grep addons | xargs -L1 -P1 .venv/bin/${PYTHON} .venv/bin/pip install -e
+	.venv/bin/${PYTHON} .venv/bin/pip install -e .
 	touch $$@
 
 prepare_node_$(1): ./docker/markers/docker_node_$(1)_venv.marker

--- a/k2/pip.conf
+++ b/k2/pip.conf
@@ -1,2 +1,5 @@
 [global]
-index-url = http://pip.zenterio.lan/simple
+index-url = http://pip.example.com:8080/
+
+[install]
+trusted-host = pip.example.com

--- a/k2/requirements-dev.txt
+++ b/k2/requirements-dev.txt
@@ -16,4 +16,5 @@ Sphinx==1.7.2
 sphinxcontrib-plantuml==0.11
 sphinxprettysearchresults==0.3.4
 testfixtures==5.4.0
+xmldiff==2.4
 yapf==0.20.0

--- a/k2/requirements-dev.txt
+++ b/k2/requirements-dev.txt
@@ -10,7 +10,6 @@ flake8-string-format==0.2.3
 flake8==3.7.6
 flake8_tuple==0.2.13
 isort==4.3.0
-pdoc==0.3.2
 pydocstyle==2.1.1
 sphinx-rtd-theme==0.3.0
 Sphinx==1.7.2

--- a/k2/requirements.txt
+++ b/k2/requirements.txt
@@ -1,4 +1,3 @@
---trusted-host pip.zenterio.lan
 addons/k2-addon
 addons/k2-connectioncheck
 addons/k2-consolerunner
@@ -22,21 +21,22 @@ addons/k2-sispmpowerswitch
 addons/k2-sutevents
 addons/k2-telnet
 addons/k2-zelenium
-numpy==1.13.3 --only-binary numpy
+numpy==1.19.4 --only-binary numpy
 arrow==0.12.1
 docker-pycreds==0.4.0
 docker==3.7.0
 fastentrypoints==0.10
 GitPython==2.1.9
-httpretty==0.9.5
+httpretty==1.0.3
 jinja2==2.9.6
-matplotlib==2.1.1 --only-binary matplotlib
+junit-xml==1.8
+matplotlib==3.3.3 --only-binary matplotlib
 nose-timer==0.7.3
 nose==1.3.7
-pandas==0.20.1 --only-binary pandas
+pandas==1.1.4 --only-binary pandas
 pretenders==1.4.4
+pyserial==3.5
 python-jenkins==1.4.0
-junit-xml==1.8
 pytracing==0.2
 selenium==3.9.0
 simple-websocket-server==0.4.0
@@ -44,4 +44,4 @@ testinfra==1.16.0 --only-binary testinfra
 thrift==0.10.0
 wakeonlan==1.1.6
 websocket-client==0.55.0
-zenterio-zaf==0.28.1
+zenterio-zaf

--- a/k2/systest/systest_plugins/serialmock/serialmock.py
+++ b/k2/systest/systest_plugins/serialmock/serialmock.py
@@ -2,10 +2,9 @@ import logging
 import subprocess
 from tempfile import mktemp
 
+from serial import Serial
 from zaf.component.decorator import component
 from zaf.extensions.extension import CommandExtension, get_logger_name
-
-from serial import Serial
 
 logger = logging.getLogger(get_logger_name('k2', 'serialmock'))
 logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
Summary of changes:
* A stub `k2-multirunner` addon has been added. It doesn't provide any extensions; only the definitions of `MULTI_RUNNER_ENABLED`, `MULTI_RUNNER_ENDPOINT`, and `TEST_SUBRUN`.
* System tests that rely on the "multirunner" extension have been skipped. The ExtensionMananger component is used to check for the existence of the "multirunner" extension so if `k2-multirunner` gets re-introduced, these tests should automatically get re-enabled again. The addons that depend on `k2-multirunner` are:
  * `k2-consolerunner`
  * `k2-gtestbinaryrunner`
* The order of attributes in an XML tag changes between python and/or OS versions, so a third party library was introduced to help the unit tests pass for the test report writers.
* Various dependencies have been updated to newer versions due to old versions no longer being available at pypi.
* Other minor fixes

It is recommended that each commit be reviewed individually.

These changes have been tested on both Ubuntu server 18.04 (python 3.6) and Arch Linux (python 3.9)