### PR TITLE
k2: allow serial port to be temporarily suspended

### DIFF
--- a/k2/addons/k2-serial/zserial/__init__.py
+++ b/k2/addons/k2-serial/zserial/__init__.py
@@ -28,6 +28,18 @@ SERIAL_RECONNECT = MessageId(
     Trigger a reconnect of the serial connection
     """)
 
+SERIAL_SUSPEND = MessageId(
+    'SERIAL_SUSPEND', """\
+    Suspends log line handling and returns a reference to the serial port. This
+    can be used when raw byte access is temporarily needed. The log line
+    handling is resumed with SERIAL_RESUME.
+    """)
+
+SERIAL_RESUME = MessageId(
+    'SERIAL_RESUME', """\
+    Resumes line handling of the serial port. Counterpart of SERIAL_SUSPEND.
+    """)
+
 SERIAL_RAW_LINE = MessageId(
     'SERIAL_RAW_LINE', """\
     An event with a raw line that is read directly from the serial connection

--- a/k2/addons/k2-serial/zserial/__init__.py
+++ b/k2/addons/k2-serial/zserial/__init__.py
@@ -33,11 +33,16 @@ SERIAL_SUSPEND = MessageId(
     Suspends log line handling and returns a reference to the serial port. This
     can be used when raw byte access is temporarily needed. The log line
     handling is resumed with SERIAL_RESUME.
+
+    NOTE: This behavior is not thread safe. If multiple components try to
+          suspend the same serial connection at the same time, an exception
+          will be raised.
     """)
 
 SERIAL_RESUME = MessageId(
     'SERIAL_RESUME', """\
     Resumes line handling of the serial port. Counterpart of SERIAL_SUSPEND.
+    An exception will be raised if the serial port was not already suspended.
     """)
 
 SERIAL_RAW_LINE = MessageId(

--- a/k2/addons/k2-serial/zserial/serial.py
+++ b/k2/addons/k2-serial/zserial/serial.py
@@ -226,6 +226,9 @@ class SerialExtension(AbstractExtension):
             raise SerialException(
                 'Error when trying to suspend serial port: Serial connection closed')
 
+        if self._serial_connection.is_suspended():
+            raise SerialException('Trying to suspend a serial connection that is already suspended')
+
         self._serial_connection.suspend()
         return self._serial_connection.instance()
 
@@ -235,8 +238,10 @@ class SerialExtension(AbstractExtension):
             raise SerialException(
                 'Error when trying to resume serial port: Serial connection closed')
 
-        if self._serial_connection.is_suspended():
-            self._serial_connection.resume()
+        if not self._serial_connection.is_suspended():
+            raise SerialException('Trying to resume a serial connection that is not suspended')
+
+        self._serial_connection.resume()
 
     @sequential_dispatcher(
         [SERIAL_CONNECTION_LOST, SERIAL_RECONNECT], [SERIAL_ENDPOINT], entity_option_id=SUT)

--- a/k2/addons/k2-serial/zserial/serial.py
+++ b/k2/addons/k2-serial/zserial/serial.py
@@ -65,6 +65,8 @@ class RawSerialPort(object):
     Temporarily suspend the packetized log line handling to provide raw byte
     access to the serial port.
 
+    .. warning:: This component is not thread safe. Suspending the same serial port multiple times will break.
+
     Example:
 
     .. code-block:: python

--- a/k2/addons/k2-serial/zserial/test/test_client.py
+++ b/k2/addons/k2-serial/zserial/test/test_client.py
@@ -170,6 +170,7 @@ def run_with_client(run, responses={}, expected_exit_code=None):
     :return: queue with the written lines
     """
     connection = MagicMock()
+    connection.is_suspended = MagicMock(return_value=False)
     written_lines = queue.Queue()
 
     with patch('zserial.serial.find_serial_port', return_value=('device', False)), \


### PR DESCRIPTION
I'm currently doing some development on a device (https://en.wikipedia.org/wiki/CHIP_(computer)) with a rather flaky wifi connection, so I want to be able to transfer files to and from a SUT using the serial port instead. This is possible if we temporarily suspend the log line handling of the serial port and let the _xmodem_ python module do the actual transfer.