### PR TITLE
Topic disable systest extensions

### DIFF
--- a/k2/systest/systest_config.yaml
+++ b/k2/systest/systest_config.yaml
@@ -3,6 +3,7 @@ plugins.paths:
   - systest/systest_plugins
 ext.connectioncheck.enabled: false
 ext.coredumps.enabled: false
+ext.dummypowermeter.enabled: false
 ext.gtestrunner.enabled: false
 ext.healthcheck.enabled: false
 ext.iprcu.enabled: false

--- a/k2/systest/systest_config.yaml
+++ b/k2/systest/systest_config.yaml
@@ -5,6 +5,7 @@ ext.connectioncheck.enabled: false
 ext.coredumps.enabled: false
 ext.dummypowermeter.enabled: false
 ext.gtestrunner.enabled: false
+ext.gude.enabled: false
 ext.healthcheck.enabled: false
 ext.iprcu.enabled: false
 ext.iprcucc.enabled: false


### PR DESCRIPTION
These extensions require `--suts-ids` and prevents systest from starting.