### PR TITLE
zaf: swallow EOFError exception in RemoteBlocker::__exit__()

### DIFF
--- a/zaf/zaf/builtin/blocker/remote.py
+++ b/zaf/zaf/builtin/blocker/remote.py
@@ -61,14 +61,18 @@ class RemoteBlocker(object):
         return message.message_id.name == BLOCKING_COMPLETED.name
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._blocking_started_queue:
-            self._blocking_started_queue.__exit__(None, None, None)
+        try:
+            if self._blocking_started_queue:
+                self._blocking_started_queue.__exit__(None, None, None)
 
-        if self._blocking_finished_queue:
-            self._blocking_finished_queue.__exit__(None, None, None)
+            if self._blocking_finished_queue:
+                self._blocking_finished_queue.__exit__(None, None, None)
 
-        if not self._stop_blocking_sent:
-            self.stop_blocking()
+            if not self._stop_blocking_sent:
+                self.stop_blocking()
+        except EOFError:
+            # remote already disconnected
+            pass
 
 
 @FrameworkExtension(


### PR DESCRIPTION
In some systests, the remote manage to disconnect before `__exit__()`  is called. Since we're already shutting down, it should be ok to ignore this exception.