### PR TITLE
k2: refactor telnet systest to avoid race condition

### DIFF
--- a/k2/addons/k2-telnet/telnet/systest/test_telnet.py
+++ b/k2/addons/k2-telnet/telnet/systest/test_telnet.py
@@ -99,6 +99,7 @@ def test_sut_recovery_initiated_when_telnet_connection_check_fails(
         '--remote-port {remote_port} '
         '--blocker-enabled true '
         '--blocker-init-enabled true '
+        '--blocker-exit-enabled true '
         'run --suts-ids box --suts-box@ip invalid_ip '
         '--suts-box@telnet-enabled true '
         '--suts-box@telnet-port -3 '
@@ -112,5 +113,6 @@ def test_sut_recovery_initiated_when_telnet_connection_check_fails(
             with client.local_message_queue([SUT_RECOVERY_PERFORM], entities=['box']) as queue:
                 blocker_helper.stop_init_blocking(client)
                 queue.get(timeout=10)
+            blocker_helper.stop_exit_blocking(client)
     finally:
         process.wait(timeout=10)

--- a/zaf/zaf/builtin/blocker/__init__.py
+++ b/zaf/zaf/builtin/blocker/__init__.py
@@ -28,6 +28,22 @@ BLOCKER_INIT_TIMEOUT = ConfigOptionId(
     hidden=True,
     application_contexts=ApplicationContext.EXTENDABLE)
 
+BLOCKER_EXIT_ENABLED = ConfigOptionId(
+    'blocker.exit.enabled',
+    'Enable blocking on exit of zaf. ID for blocking is "exit".',
+    option_type=bool,
+    default=False,
+    hidden=True,
+    application_contexts=ApplicationContext.EXTENDABLE)
+
+BLOCKER_EXIT_TIMEOUT = ConfigOptionId(
+    'blocking.exit.timeout',
+    'Timeout for exit blocking.',
+    option_type=float,
+    default=5.0,
+    hidden=True,
+    application_contexts=ApplicationContext.EXTENDABLE)
+
 BLOCKER_ENDPOINT = EndpointId('blocker', 'Endpoint for blocker extension')
 
 StartBlockingInfo = namedtuple(

--- a/zaf/zaf/builtin/blocker/remote.py
+++ b/zaf/zaf/builtin/blocker/remote.py
@@ -10,6 +10,9 @@ class BlockerHelper(object):
     def stop_init_blocking(self, remote_client):
         remote_client.send_request(STOP_BLOCKING_ON_MESSAGE, entity='init')
 
+    def stop_exit_blocking(self, remote_client):
+        remote_client.send_request(STOP_BLOCKING_ON_MESSAGE, entity='exit', is_async=True)
+
     def stop_blocking(self, remote_client, id):
         remote_client.send_request(STOP_BLOCKING_ON_MESSAGE, entity=id)
 


### PR DESCRIPTION
This change, together with #21, should make this systest a bit more stable. I never had an issue on Arch Linux, but on Ubuntu Server, the external zk2 process managed to exit before the client received the `SUT_RECOVERY_PERFORM` message.