### PR TITLE
k2: add k2-upgrade addon

### DIFF
--- a/k2/addons/k2-upgrade/setup.py
+++ b/k2/addons/k2-upgrade/setup.py
@@ -1,0 +1,24 @@
+import os
+
+from setuptools import find_packages, setup
+
+setup(
+    name='k2-upgrade',
+    version='0.0.1' + os.getenv('BUILD_NUMBER', '0'),
+    description='Upgrade SUT software',
+    long_description=('Interface addon for upgrading software on a SUT'),
+    maintainer='Patrik Dahlström',
+    maintainer_email='risca@dalakolonin.se',
+    license='Apache 2.0',
+    packages=find_packages(
+        exclude=[
+            '*.test', '*.test.*', 'test.*', 'test', '*.systest', '*.systest.*', 'systest.*',
+            'systest'
+        ]),
+    install_requires=[''],
+    entry_points={
+        'k2.addons': [
+            'upgradecommand = upgrade.upgradecommand:UpgradeExtension',
+        ],
+    },
+)

--- a/k2/addons/k2-upgrade/upgrade/__init__.py
+++ b/k2/addons/k2-upgrade/upgrade/__init__.py
@@ -1,0 +1,24 @@
+from zaf.config.options import ConfigOptionId
+from zaf.config.types import ConfigChoice
+from zaf.messages.message import MessageId
+
+from k2.sut import SUT
+
+K2_UPGRADE_COMPONENT = 'Upgrader'
+UPGRADE_DEFAULT_TIMEOUT = 1800
+
+AVAILABLE_UPGRADE_TYPES = ConfigOptionId(
+    'upgrade.available', 'A collection of all available upgrade types', multiple=True)
+
+UPGRADE_TYPE = ConfigOptionId(
+    'upgrade.type',
+    'The type of upgrade.',
+    at=SUT,
+    option_type=ConfigChoice(AVAILABLE_UPGRADE_TYPES))
+
+PERFORM_UPGRADE = MessageId(
+    'PERFORM_UPGRADE', """\
+    Perform a full software upgrade.
+
+    exception if something failed.
+    """)

--- a/k2/addons/k2-upgrade/upgrade/upgradecommand.py
+++ b/k2/addons/k2-upgrade/upgrade/upgradecommand.py
@@ -1,0 +1,81 @@
+"""
+Upgrade SUT software.
+
+Interface addon for upgrading software on a SUT.
+"""
+
+import logging
+
+from zaf.commands.command import CommandId
+from zaf.config.options import ConfigOption, ConfigOptionId
+from zaf.extensions.extension import FrameworkExtension, get_logger_name
+from zaf.utils.future import FuturesCollection
+
+from k2.sut import SUT
+from upgrade.upgrader import Upgrader
+
+logger = logging.getLogger(get_logger_name('k2', 'upgrade'))
+
+
+def upgrade(core):
+    """Upgrades SUTs with the given software."""
+    software = core.config.get(UPGRADE_SOURCE)
+    suts = core.config.get(SUT)
+
+    error_occurred = False
+    future_sut = dict()
+    for sut in suts:
+        try:
+            upgrader = Upgrader(core.messagebus, sut, None)
+            future = upgrader.start_upgrade(software)
+            future_sut[future] = sut
+        except Exception:
+            msg = 'Error starting upgrade for sut {sut}'.format(sut=sut)
+            logger.debug(msg, exc_info=True)
+            logger.warning(msg)
+            error_occurred = True
+            pass
+
+    futures = FuturesCollection(future_sut.keys())
+    for future in futures.as_completed():
+        exception = future.exception()
+        if exception:
+            try:
+                raise exception
+            except Exception as e:
+                msg = 'Failed to upgrade sut {sut}: {exception}'.format(
+                    sut=future_sut[future], exception=str(e))
+                logger.debug(msg, exc_info=True)
+                logger.warning(msg)
+                error_occurred = True
+        else:
+            logger.info('Successfully upgraded sut {sut}'.format(sut=future_sut[future]))
+
+    return 1 if error_occurred else 0
+
+
+UPGRADE_SOURCE = ConfigOptionId(
+    'upgrade.source',
+    'The software to upgrade to. Usully the path to an upgrade package.',
+    option_type=str,
+    argument=True)
+
+UPGRADE_COMMAND = CommandId(
+    'upgrade',
+    upgrade.__doc__,
+    upgrade,
+    config_options=[ConfigOption(UPGRADE_SOURCE, required=True),
+                    ConfigOption(SUT, required=True)],
+    uses=['sut'])
+
+
+@FrameworkExtension(
+    name='upgrade',
+    commands=[UPGRADE_COMMAND],
+    groups=['upgrade'],
+)
+class UpgradeExtension(object):
+    """Provides the upgrade command."""
+
+    def __init__(self, config, instances):
+        pass

--- a/k2/addons/k2-upgrade/upgrade/upgrader.py
+++ b/k2/addons/k2-upgrade/upgrade/upgrader.py
@@ -1,0 +1,60 @@
+import logging
+from concurrent.futures import TimeoutError
+
+from zaf.extensions.extension import get_logger_name
+
+from upgrade import PERFORM_UPGRADE, UPGRADE_DEFAULT_TIMEOUT
+
+logger = logging.getLogger(get_logger_name('k2', 'upgrade'))
+
+
+class NoUpgradeTypes(Exception):
+    pass
+
+
+class MultipleUpgradeTypes(Exception):
+    pass
+
+
+class UpgradeFailed(Exception):
+    pass
+
+
+class Upgrader(object):
+
+    def __init__(self, messagebus, entity, receiver_endpoint_id):
+        self.messagebus = messagebus
+        self.entity = entity
+        self.receiver_endpoint_id = receiver_endpoint_id
+
+    def _singular_future_or_raise(self, futures):
+        if len(futures) == 0:
+            msg = 'Upgrade failed due to no upgrade types available for sut {sut}'.format(
+                sut=self.entity)
+            logger.error(msg)
+            raise NoUpgradeTypes(msg)
+        elif len(futures) > 1:
+            msg = 'Upgrade failed due to multiple upgrade types registered for sut {sut}'.format(
+                sut=self.entity)
+            logger.error(msg)
+            raise MultipleUpgradeTypes(msg)
+
+    def start_upgrade(self, software):
+        logger.info('Upgrading sut {sut}'.format(sut=self.entity))
+        futures = self.messagebus.send_request(
+            PERFORM_UPGRADE,
+            receiver_endpoint_id=self.receiver_endpoint_id,
+            entity=self.entity,
+            data=software)
+        self._singular_future_or_raise(futures)
+        return futures[0]
+
+    def perform_upgrade(self, software):
+        """Perform software upgrade."""
+        try:
+            return self.start_upgrade(software).wait(timeout=UPGRADE_DEFAULT_TIMEOUT)
+        except TimeoutError:
+            msg = 'Timeout while waiting for sut {sut} to upgrade "{sw}"'.format(
+                sut=self.entity, sw=software)
+            logger.error(msg)
+            raise UpgradeFailed(msg) from None

--- a/k2/requirements.txt
+++ b/k2/requirements.txt
@@ -20,6 +20,7 @@ addons/k2-serial
 addons/k2-sispmpowerswitch
 addons/k2-sutevents
 addons/k2-telnet
+addons/k2-upgrade
 addons/k2-zelenium
 numpy==1.19.4 --only-binary numpy
 arrow==0.12.1


### PR DESCRIPTION
This is an interface addon for performing software upgrade. It follows the same layout as the "k2-power" addon and allow multiple types of upgrades to be available, but only 1 enabled at a time.

It defines 1 message that the implementations needs to listen on: `PERFORM_UPGRADE`
It adds 1 new command (`upgrade`) that take 1 argument: `UPGRADE_SOURCE`, where source could potentially be a keyword or the path to an upgrade package.