### PR TITLE
k2: allow specifying serial port as url

### DIFF
--- a/k2/addons/k2-serial/zserial/__init__.py
+++ b/k2/addons/k2-serial/zserial/__init__.py
@@ -59,7 +59,7 @@ SERIAL_BAUDRATE = ConfigOptionId(
 
 SERIAL_DEVICE = ConfigOptionId(
     'serial.device',
-    'The serial device. Multiple formats supported e.g [ttyXXX, /dev/ttyXXX, 3-10.5.1, guess]',
+    'The serial device. Multiple formats supported e.g [ttyXXX, /dev/ttyXXX, 3-10.5.1, socket://127.0.0.1:2012, guess]',
     at=SUT)
 
 SERIAL_TIMEOUT = ConfigOptionId(

--- a/k2/addons/k2-serial/zserial/serial.py
+++ b/k2/addons/k2-serial/zserial/serial.py
@@ -158,6 +158,8 @@ class SerialExtension(AbstractExtension):
                 self._serial_connection = start_serial_connection(
                     self._port, self._baudrate, self._virtual, self._timeout, messagebus,
                     self._entity, self._filters)
+                logger.debug(
+                    'Opened {port} for sut {sut}'.format(port=self._port, sut=self._entity))
                 return
             except Exception:
                 logger.debug(

--- a/k2/addons/k2-serial/zserial/test/test_connection.py
+++ b/k2/addons/k2-serial/zserial/test/test_connection.py
@@ -160,3 +160,12 @@ class TestFindSerialPort(TestCase):
         with patch('zserial.connection.comports', return_value=self.devices()), \
                 patch('os.path.exists', return_value=False):
             self.assertRaises(PortNotFound, find_serial_port, 'not a port')
+
+    def test_invalid_url_raises_exception(self):
+        with patch('zserial.connection.serial_for_url', side_effect=Exception('Boom!')):
+            self.assertRaises(PortNotFound, find_serial_port, 'invalid://url')
+
+    def test_port_can_be_found_using_url(self):
+        url = 'valid://url'
+        with patch('zserial.connection.serial_for_url', return_value=MagicMock()):
+            self.assertEqual(find_serial_port(url), (url, True))


### PR DESCRIPTION
This allow the full range of pyserial's protocol handlers, e.g. direct TCP connection to a ser2net instance :smiley_cat: 