### PR TITLE
Bump zaf to 1.1.1

### DIFF
--- a/k2/requirements.txt
+++ b/k2/requirements.txt
@@ -46,4 +46,4 @@ testinfra==1.16.0 --only-binary testinfra
 thrift==0.10.0
 wakeonlan==1.1.6
 websocket-client==0.55.0
-../packages/zenterio-zaf-1.1.0.post0.tar.gz
+../packages/zenterio-zaf-1.1.1.post0.tar.gz

--- a/zaf/znake.yaml
+++ b/zaf/znake.yaml
@@ -9,6 +9,12 @@ znake:
           events, plugins/addons, metric collection, logging, configuration and
           command line argument parsing.
         changelog:
+          - version: 1.1.1
+            changes:
+              - 'Add support for blocking on exit'
+              - 'Swallow EOFError exception in RemoteBlocker::__exit__()'
+              - 'Minor compatibility fixes for python3.9 and flake8'
+            date: Sat, 22 Mar 2021 00:00:00 +0200
           - version: 1.1.0
             changes:
               - 'Do not deactivate the applications signal handler when command is complete.'


### PR DESCRIPTION
The following K2 systest requires the block-on-exit systest utility from latest zaf:
* `telnet.systest.test_telnet.test_sut_recovery_initiated_when_telnet_connection_check_fails'