### PR TITLE
k2: expect reset when powering on and off sut

### DIFF
--- a/k2/addons/k2-power/powerswitch/powerswitch.py
+++ b/k2/addons/k2-power/powerswitch/powerswitch.py
@@ -107,5 +107,6 @@ class SutPowerControl(object):
         self._sutevents = sutevents
 
     def power_cycle_sut(self, off_time=POWER_CYCLE_TIME):
-        with self._sutevents.await_sut_reset_done():
-            self._switch.off_then_on(off_time=off_time)
+        with self._sutevents.expect_reset():
+            with self._sutevents.await_sut_reset_done():
+                self._switch.off_then_on(off_time=off_time)


### PR DESCRIPTION
This change might have unknown consequences since it will trigger K2 runner to pause execution, something it didn't do before. On the other hand, this is necessary for notifying SutEventsTimeExtension that we're resetting the sut. It relies on receiving the SUT_RESET_EXPECTED message to start its timer.