### PR TITLE
k2: Log line sources

### DIFF
--- a/k2/addons/k2-serial/setup.py
+++ b/k2/addons/k2-serial/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'k2.addons': [
             'zserial = zserial.serial:SerialExtension',
+            'zseriallogsource = zserial.serial:SerialLogSourceExtension',
             'zserialcc = zserial.serialcc:SerialConnectionCheck',
             'zserialcommand = zserial.serialcommand:SerialFrameworkExtension',
         ],

--- a/k2/addons/k2-serial/zserial/__init__.py
+++ b/k2/addons/k2-serial/zserial/__init__.py
@@ -53,6 +53,17 @@ SERIAL_RAW_LINE = MessageId(
 SERIAL_ENABLED = ConfigOptionId(
     'serial.enabled', 'Should serial be enabled', at=SUT, option_type=bool, default=False)
 
+SERIAL_LOG_ENABLED = ConfigOptionId(
+    'serial.log',
+    """\
+    Should serial trigger LOG_LINE_RECEIVED events.
+
+    LOG_LINE_RECEIVED events are used by other extensions (e.g. SutEvents) to provide additional
+    functionality and components.""",
+    at=SUT,
+    option_type=bool,
+    default=True)
+
 SERIAL_CONNECTION_CHECK_ENABLED = ConfigOptionId(
     'serialcc.enabled',
     'Should serial connection check be enabled',

--- a/k2/addons/k2-serial/zserial/client.py
+++ b/k2/addons/k2-serial/zserial/client.py
@@ -10,6 +10,7 @@ from zaf.messages.dispatchers import LocalMessageQueue
 from sutevents import LOG_LINE_RECEIVED
 from zserial import SERIAL_ENDPOINT, SERIAL_SEND_COMMAND
 
+from .log import serial_log_line_entity
 from .messages import SendSerialCommandData
 
 logger = logging.getLogger(get_logger_name('k2', 'zserial'))
@@ -47,6 +48,7 @@ class SerialClient(object):
         """
         self.messagebus = messagebus
         self.entity = entity
+        self.log_entity = serial_log_line_entity(self.entity)
         self.default_timeout = timeout
         self.default_endmark = re.compile(endmark)
 
@@ -104,7 +106,7 @@ class SerialClient(object):
         timeout = timeout if timeout is not None else self.default_timeout
         start_time = time.time()
         with LocalMessageQueue(self.messagebus, [LOG_LINE_RECEIVED], [SERIAL_ENDPOINT],
-                               [self.entity]) as queue:
+                               [self.log_entity]) as queue:
             serial_send_data = SendSerialCommandData(line, timeout)
             try:
                 serial_send_response = self.messagebus.send_request(

--- a/k2/addons/k2-serial/zserial/connection.py
+++ b/k2/addons/k2-serial/zserial/connection.py
@@ -11,6 +11,8 @@ from zaf.extensions.extension import get_logger_name
 from sutevents import LOG_LINE_RECEIVED
 from zserial import SERIAL_CONNECTED, SERIAL_CONNECTION_LOST, SERIAL_ENDPOINT, SERIAL_RAW_LINE
 
+from .log import serial_log_line_entity
+
 logger = logging.getLogger(get_logger_name('k2', 'zserial'))
 
 rawlogger = logging.getLogger('rawserial')
@@ -123,6 +125,7 @@ def _serial_connection(messagebus_arg, entity_arg, inline_filters_arg=None):
     class SerialConnection(LineReader):
         messagebus = messagebus_arg
         entity = entity_arg
+        log_entity = serial_log_line_entity(entity_arg)
         inline_filters = inline_filters_arg if inline_filters_arg else []
 
         def __init__(self):
@@ -175,7 +178,7 @@ def _serial_connection(messagebus_arg, entity_arg, inline_filters_arg=None):
                 if filtered:
                     logger.debug(filtered)
                     self.messagebus.trigger_event(
-                        LOG_LINE_RECEIVED, SERIAL_ENDPOINT, self.entity, filtered)
+                        LOG_LINE_RECEIVED, SERIAL_ENDPOINT, self.log_entity, filtered)
                     if reached_end_of_line:
                         self.stack.append(remaining)
                     else:
@@ -183,10 +186,11 @@ def _serial_connection(messagebus_arg, entity_arg, inline_filters_arg=None):
                 else:
                     logger.debug(remaining)
                     self.messagebus.trigger_event(
-                        LOG_LINE_RECEIVED, SERIAL_ENDPOINT, self.entity, remaining)
+                        LOG_LINE_RECEIVED, SERIAL_ENDPOINT, self.log_entity, remaining)
             else:
                 logger.debug(line)
-                self.messagebus.trigger_event(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, self.entity, line)
+                self.messagebus.trigger_event(
+                    LOG_LINE_RECEIVED, SERIAL_ENDPOINT, self.log_entity, line)
 
     return SerialConnection
 

--- a/k2/addons/k2-serial/zserial/log.py
+++ b/k2/addons/k2-serial/zserial/log.py
@@ -1,0 +1,2 @@
+def serial_log_line_entity(entity):
+    return 'serial-{entity}'.format(entity=entity)

--- a/k2/addons/k2-serial/zserial/test/test_client.py
+++ b/k2/addons/k2-serial/zserial/test/test_client.py
@@ -182,7 +182,7 @@ def run_with_client(run, responses={}, expected_exit_code=None):
 
             for response_line in responses.get(line, []):
                 harness.messagebus.trigger_event(
-                    LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', response_line)
+                    LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', response_line)
 
         connection.write_line.side_effect = write_line
 

--- a/k2/addons/k2-serial/zserial/test/test_connection.py
+++ b/k2/addons/k2-serial/zserial/test/test_connection.py
@@ -44,8 +44,8 @@ class TestSerialConnection(TestCase):
 
         messagebus.trigger_event.assert_has_calls(
             [
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', '### error'),
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', 'line'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', '### error'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', 'line'),
             ])
 
     def test_parse_raw_line_with_filter_with_multiple_end_of_line_patterns(self):
@@ -58,9 +58,9 @@ class TestSerialConnection(TestCase):
 
         messagebus.trigger_event.assert_has_calls(
             [
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', '!!! warning'),
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', '### error'),
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', 'line'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', '!!! warning'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', '### error'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', 'line'),
             ])
 
     def test_parse_raw_line_with_filter_with_multiple_in_line_patterns(self):
@@ -71,9 +71,9 @@ class TestSerialConnection(TestCase):
 
         messagebus.trigger_event.assert_has_calls(
             [
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', '!!! warning'),
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', '### error'),
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', 'line'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', '!!! warning'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', '### error'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', 'line'),
             ])
 
     def test_parse_raw_line_with_filter_matches_full_line(self):
@@ -84,7 +84,7 @@ class TestSerialConnection(TestCase):
 
         messagebus.trigger_event.assert_has_calls(
             [
-                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'entity', '### error'),
+                call(LOG_LINE_RECEIVED, SERIAL_ENDPOINT, 'serial-entity', '### error'),
             ])
 
     def test_trigger_connection_lost_message_on_connection_lost(self):

--- a/k2/addons/k2-sutevents/sutevents/suteventstime.py
+++ b/k2/addons/k2-sutevents/sutevents/suteventstime.py
@@ -8,9 +8,9 @@ from zaf.messages.decorator import callback_dispatcher, sequential_dispatcher
 from k2.cmd.run import RUN_COMMAND, UNINITIALIZE_SUT
 from k2.sut import SUT, SUT_RESET_DONE, SUT_RESET_DONE_TIMEOUT, SUT_RESET_EXPECTED, \
     SUT_RESET_NOT_EXPECTED, SUT_RESET_STARTED
+from k2.sut.log import SUT_LOG_SOURCES
 from k2.utils.threading import ResetableTimer
 from sutevents import IS_SUT_RESET_EXPECTED
-from zserial import SERIAL_ENABLED
 
 from . import SUT_RESET_DONE_PATTERN, SUT_RESET_STARTED_PATTERN, SUTEVENTSTIME_ENDPOINT
 from .components import SutEvents  # noqa
@@ -24,7 +24,7 @@ logger = logging.getLogger(get_logger_name('k2', 'sutevents.time'))
     config_options=[
         ConfigOption(SUT, required=True, instantiate_on=True),
         ConfigOption(SUT_RESET_DONE_TIMEOUT, required=True),
-        ConfigOption(SERIAL_ENABLED, required=False),
+        ConfigOption(SUT_LOG_SOURCES, required=False),
         ConfigOption(SUT_RESET_STARTED_PATTERN, required=False),
         ConfigOption(SUT_RESET_DONE_PATTERN, required=False),
     ],
@@ -37,7 +37,7 @@ logger = logging.getLogger(get_logger_name('k2', 'sutevents.time'))
             SUT_RESET_NOT_EXPECTED,
         ]
     },
-    deactivate_on=[SERIAL_ENABLED, SUT_RESET_STARTED_PATTERN, SUT_RESET_DONE_PATTERN])
+    deactivate_on=[SUT_LOG_SOURCES, SUT_RESET_STARTED_PATTERN, SUT_RESET_DONE_PATTERN])
 class SutEventsTimeExtension(AbstractExtension):
     """
     A time-based implementation that should only be used if logs are not available.

--- a/k2/addons/k2-sutevents/sutevents/systest/data/suites/test_loglines.py
+++ b/k2/addons/k2-sutevents/sutevents/systest/data/suites/test_loglines.py
@@ -1,6 +1,7 @@
 from zaf.component.decorator import component, requires
 from zaf.messages.message import EndpointId
 
+from k2.sut.log import sut_add_log_source
 from sutevents import LOG_LINE_RECEIVED
 
 LOG_LINE_GENERATOR_ENDPOINT = EndpointId('log-line-generator', '')
@@ -8,18 +9,24 @@ LOG_LINE_GENERATOR_ENDPOINT = EndpointId('log-line-generator', '')
 
 @requires(messagebus='MessageBus')
 @requires(sut='Sut')
+@requires(config='Config')
 @component(scope='session')
 class LogLineGenerator(object):
 
-    def __init__(self, messagebus, sut):
+    def __init__(self, messagebus, sut, config):
         self._messagebus = messagebus
         self._sut = sut
+        self._log_entity = 'loglinegenerator-{sut}'.format(sut=self._sut)
+        self._config = config
 
     def __call__(self, line):
         self._messagebus.trigger_event(
-            LOG_LINE_RECEIVED, LOG_LINE_GENERATOR_ENDPOINT, entity=self._sut.entity, data=line)
+            LOG_LINE_RECEIVED, LOG_LINE_GENERATOR_ENDPOINT, entity=self._log_entity, data=line)
 
     def __enter__(self):
+        config = {}
+        sut_add_log_source(config, self._sut.entity, self._log_entity)
+        self._config.update_config(config, -1, 'LogLineGenerator')
         self._messagebus.define_endpoints_and_messages(
             {
                 LOG_LINE_GENERATOR_ENDPOINT: [LOG_LINE_RECEIVED]

--- a/k2/addons/k2-sutevents/sutevents/test/test_suteventslog.py
+++ b/k2/addons/k2-sutevents/sutevents/test/test_suteventslog.py
@@ -29,9 +29,9 @@ class TestSutEventsLogExtension(TestCase):
         with create_log_harness(reset_started_pattern='STARTED') as harness:
             with harness.message_queue([SUT_RESET_STARTED], entities=['entity']) as queue:
                 harness.trigger_event(
-                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='entity', data='Not a match')
+                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='log-entity', data='Not a match')
                 harness.trigger_event(
-                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='entity', data='STARTED')
+                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='log-entity', data='STARTED')
                 self.assertEqual(queue.get(timeout=2).message_id, SUT_RESET_STARTED)
                 with self.assertRaises(Empty):
                     queue.get_nowait()
@@ -40,9 +40,9 @@ class TestSutEventsLogExtension(TestCase):
         with create_log_harness(reset_done_pattern='DONE') as harness:
             with harness.message_queue([SUT_RESET_DONE], entities=['entity']) as queue:
                 harness.trigger_event(
-                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='entity', data='Not a match')
+                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='log-entity', data='Not a match')
                 harness.trigger_event(
-                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='entity', data='DONE')
+                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='log-entity', data='DONE')
                 self.assertEqual(queue.get(timeout=2).message_id, SUT_RESET_DONE)
                 with self.assertRaises(Empty):
                     queue.get_nowait()
@@ -51,7 +51,7 @@ class TestSutEventsLogExtension(TestCase):
         with create_log_harness(reset_done_pattern='DONE', reset_done_delay=0.01) as harness:
             with harness.message_queue([SUT_RESET_DONE], entities=['entity']) as queue:
                 harness.trigger_event(
-                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='entity', data='DONE')
+                    LOG_LINE_RECEIVED, MOCK_ENDPOINT, entity='log-entity', data='DONE')
                 self.assertEqual(queue.get(timeout=2).message_id, SUT_RESET_DONE)
                 self.assertEqual(harness.extension.pattern_handlers['DONE'].interval, 0.01)
 

--- a/k2/addons/k2-sutevents/sutevents/test/utils.py
+++ b/k2/addons/k2-sutevents/sutevents/test/utils.py
@@ -7,18 +7,19 @@ from zaf.messages.message import EndpointId
 from k2.cmd.run import UNINITIALIZE_SUT
 from k2.sut import SUT, SUT_RESET_DONE, SUT_RESET_DONE_TIMEOUT, SUT_RESET_EXPECTED, \
     SUT_RESET_NOT_EXPECTED
+from k2.sut.log import SUT_LOG_SOURCES
 from sutevents import LOG_LINE_RECEIVED, SUT_RESET_DONE_DELAY, SUT_RESET_DONE_PATTERN, \
     SUT_RESET_STARTED_PATTERN
 from sutevents.components import SutEvents, SutEventsComponentExtension
 from sutevents.suteventslog import SutEventsLogExtension
 from sutevents.suteventstime import SutEventsTimeExtension
-from zserial import SERIAL_ENABLED
 
 MOCK_ENDPOINT = EndpointId('mock', 'Mock endpoint')
 
 
 def create_log_harness(
         sut=['entity'],
+        log_sources=['log-entity'],
         reset_started_pattern='START_PATTERN',
         reset_done_pattern='DONE_PATTERN',
         reset_done_delay=0):
@@ -27,7 +28,7 @@ def create_log_harness(
     entity = sut[0]
     config.set(SUT, sut)
     config.set(SUT_RESET_DONE_TIMEOUT, 1, entity=entity)
-    config.set(SERIAL_ENABLED, True, entity=entity)
+    config.set(SUT_LOG_SOURCES, log_sources, entity=entity)
     config.set(SUT_RESET_STARTED_PATTERN, reset_started_pattern, entity=entity)
     config.set(SUT_RESET_DONE_PATTERN, reset_done_pattern, entity=entity)
     config.set(SUT_RESET_DONE_DELAY, reset_done_delay, entity=entity)
@@ -45,8 +46,8 @@ def create_time_harness(sut=['entity']):
     config = ConfigManager()
     entity = sut[0]
     config.set(SUT, sut)
+    config.set(SUT_LOG_SOURCES, [], entity=entity)
     config.set(SUT_RESET_DONE_TIMEOUT, 1, entity=entity)
-    config.set(SERIAL_ENABLED, False, entity=entity)
     config.set(SUT_RESET_STARTED_PATTERN, None, entity=entity)
     config.set(SUT_RESET_DONE_PATTERN, None, entity=entity)
 

--- a/k2/k2/sut/log.py
+++ b/k2/k2/sut/log.py
@@ -1,0 +1,58 @@
+"""
+Helper classes and functions for working with SUT log sources.
+
+Extensions who wish to announce that they provide a source of SUT log lines have to populated the
+:ref:`option-suts.<ids>.log.sources` config option. The easiest way to do this is by defining a
+FrameworkExtension and implementing the get_config member, like so:
+
+.. code-block:: python
+
+    @FrameworkExtension(name='zserial', load_order=91, groups=['log_sources', 'serial'])
+    class SerialLogSourceExtension(AbstractExtension):
+        def get_config(self, config, requested_config_options, requested_command_config_options):
+            log_config = dict()
+            for sut in config.get(SUT):
+                if config.get(SERIAL_ENABLED, entity=sut) and config.get(SERIAL_LOG_ENABLED,
+                                                                         entity=sut):
+                    sut_add_log_source(log_config, sut, serial_log_line_entity(sut))
+            return ExtensionConfig(log_config, 1, 'zserial')
+
+This extension would then post LOG_LINE_RECEIVED events to serial log entities it announced. Please
+note that the load_order in the above example has to be at least 91, so that any command line
+parameters have been successfully parsed. See the "Framework Extensions::Load Order" section in the
+dev guide for more details.
+
+This config option can be used by extensions who wish to react or process log lines coming from a
+sut. The extension would have to listen to LOG_LINE_RECEIVED events for the available log line
+sources, or a subset of them.
+"""
+
+from zaf.application import ApplicationContext
+from zaf.config.options import ConfigOptionId
+
+from . import SUT
+
+SUT_LOG_SOURCES = ConfigOptionId(
+    'log.sources',
+    """\
+    List of sources which can provide log lines from the sut.
+
+    Extensions which can trigger LOG_LINE_RECEIVED events will automatically extend this list.
+    """,
+    at=SUT,
+    option_type=str,
+    multiple=True,
+    hidden=True,
+    application_contexts=ApplicationContext.INTERNAL)
+
+
+class NoLogSources(Exception):
+    pass
+
+
+def sut_add_log_source(config, sut, source):
+    log_sources = '.'.join([SUT.namespace, sut, SUT_LOG_SOURCES.name])
+    try:
+        config[log_sources].append(source)
+    except KeyError:
+        config[log_sources] = [source]


### PR DESCRIPTION
I made an initial draft how to solve the log line producer/source problem discussed in #32.

I'm not entirely happy with the result. I think it's somewhat clunky to have to define a `FrameworkExtension` just so that you can populate a config, but I couldn't come up with a better idea.

~~Unfortunately, one of the sutevents systests still fail with this implementation. Seems like the test always gets the time based implementation. I'm sure it must be an issue with load order. Depending on the `load_order` of the `SerialLogSourceExtension`, I'm able to request the `SUT`s or not. Using a config _file_ works for me during manual testing :shrug:~~
Fixed now. It was a combination of too low `load_order` and a bug in my changes to the _k2-serial_ addon.