### PR TITLE
k2+zaf: minor updates and fixes

### DIFF
--- a/k2/addons/k2-orchestration/orchestration/ansible/manager.py
+++ b/k2/addons/k2-orchestration/orchestration/ansible/manager.py
@@ -85,9 +85,9 @@ class AnsibleSuts(AbstractExtension):
             selected_nodes = config.get(ANSIBLE_NODE)
 
             if selected_nodes:
-                config = {'suts.ids': selected_nodes}
+                config = {SUT.key: selected_nodes}
             else:
-                config = {'suts.ids': config.get(ANSIBLE_NODES)}
+                config = {SUT.key: config.get(ANSIBLE_NODES)}
         else:
             config = {}
 

--- a/k2/addons/k2-orchestration/orchestration/ansible/test/test_manager.py
+++ b/k2/addons/k2-orchestration/orchestration/ansible/test/test_manager.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from zaf.config.manager import ConfigManager
 
+from k2.sut import SUT
 from orchestration.ansible import ANSIBLE_ENABLED, ANSIBLE_NODE, ANSIBLE_NODES
 from orchestration.ansible.manager import AnsibleSuts
 
@@ -24,7 +25,7 @@ class TestAnsibleSuts(TestCase):
         config.set(ANSIBLE_NODES, ['1', '2', '3'])
         config.set(ANSIBLE_ENABLED, False)
         ansible_suts = AnsibleSuts(None, None)
-        self.assertNotIn('suts.ids', ansible_suts.get_config(config, [], {}).config)
+        self.assertNotIn(SUT.key, ansible_suts.get_config(config, [], {}).config)
 
     def test_get_config_uses_ansible_nodes_as_suts_when_ansible_node_is_not_set(self):
         config = ConfigManager()
@@ -33,7 +34,7 @@ class TestAnsibleSuts(TestCase):
         config.set(ANSIBLE_ENABLED, True)
         ansible_suts = AnsibleSuts(None, None)
         self.assertCountEqual(
-            ansible_suts.get_config(config, [], {}).config['suts.ids'], ['1', '2', '3'])
+            ansible_suts.get_config(config, [], {}).config[SUT.key], ['1', '2', '3'])
 
     def test_get_config_uses_ansible_node_as_suts_when_set(self):
         config = ConfigManager()
@@ -42,5 +43,4 @@ class TestAnsibleSuts(TestCase):
         config.set(ANSIBLE_NODE, ['2', '3'])
         config.set(ANSIBLE_ENABLED, True)
         ansible_suts = AnsibleSuts(None, None)
-        self.assertCountEqual(
-            ansible_suts.get_config(config, [], {}).config['suts.ids'], ['2', '3'])
+        self.assertCountEqual(ansible_suts.get_config(config, [], {}).config[SUT.key], ['2', '3'])

--- a/zaf/zaf/config/options.py
+++ b/zaf/zaf/config/options.py
@@ -91,7 +91,7 @@ class ConfigOptionId(InternalConfigOptionId):
             raise ValueError('Invalid type for config option with name {name}'.format(name=name))
 
         if entity is True:
-            if option_type not in [str, Entity]:
+            if option_type != str and type(option_type) != Entity:
                 raise ValueError(
                     "Option '{name}' is an entity and must have an option of type Entity".format(
                         name=name))

--- a/zaf/zaf/extensions/loader.py
+++ b/zaf/zaf/extensions/loader.py
@@ -191,8 +191,8 @@ class ExtensionLoader(object):
 
             extension_instances = self.extension_manager.initialize_framework_extension(
                 extension, self.config)
-            for extension_instance in extension_instances:
-                if hasattr(extension, 'get_config'):
+            if hasattr(extension, 'get_config'):
+                for extension_instance in extension_instances:
                     extension_config = extension_instance.get_config(
                         self.config, main_config_options, commands_with_config_options)
 


### PR DESCRIPTION
Summary of changes:
* zaf: only iterate over instances if _class_ has `get_config`. See commit message for more details
* zaf: fix using Entity() as option_type for entities
* k2: orchestration: use `SUT.key` instead of hard coded `'suts.ids'`